### PR TITLE
Update bfgminer to 3.8.0

### DIFF
--- a/bfgminer.rb
+++ b/bfgminer.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Bfgminer < Formula
     homepage 'https://github.com/luke-jr/bfgminer'
     head 'https://github.com/luke-jr/bfgminer.git', :branch => 'bfgminer'
-    url 'https://github.com/luke-jr/bfgminer.git', :tag => 'bfgminer-3.7.0'
-    version '3.7.0'
+    url 'http://luke.dashjr.org/programs/bitcoin/files/bfgminer/3.8.0/bfgminer-3.8.0.zip'
+    sha1 'd3f2e8afebafc8d776354c832ae7afa678555635'
     
     depends_on 'autoconf' => :build
     depends_on 'automake' => :build

--- a/bfgminer.rb
+++ b/bfgminer.rb
@@ -5,6 +5,7 @@ class Bfgminer < Formula
     head 'https://github.com/luke-jr/bfgminer.git', :branch => 'bfgminer'
     url 'http://luke.dashjr.org/programs/bitcoin/files/bfgminer/3.8.0/bfgminer-3.8.0.zip'
     sha1 'd3f2e8afebafc8d776354c832ae7afa678555635'
+    version '3.8.0'
     
     depends_on 'autoconf' => :build
     depends_on 'automake' => :build


### PR DESCRIPTION
luke-jr [recommends not pulling the source from github](https://github.com/luke-jr/bfgminer/issues/195#issuecomment-11426085). That, and considering the v3.8 is only officially released on his download site, I switched away from pulling versions from the github repo.
